### PR TITLE
build(makefile): target to install as cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,6 @@ clean: ## Remove all build files
 install: $(UV_PATH) requirements.txt $(REQS) ## Install development requirements (default)
 	@echo "Installing $(filter-out $<,$^)"
 	@python -m uv pip sync $(filter-out $<,$^)
+
+cli: $(UV_PATH) ## Install the CLI
+	uv pip install --editable .


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add a "cli" target to the Makefile that installs the current project in editable mode using `uv pip install --editable .`.